### PR TITLE
Feature/player can move to new room

### DIFF
--- a/Skyscii/Menu/BattleMenu.cs
+++ b/Skyscii/Menu/BattleMenu.cs
@@ -94,14 +94,13 @@ namespace Skyscii
                     // means they have killed everyone in the room -> they should move to the next room, 
                     // or if there is no next room, to the dungeon selection menu
 
-                    // another room remains to be explored.
-                    if (player.Location.NextRoom != null) {
-                        player.Location = player.Location.NextRoom;
-                        flavourText = "you move to the next room in the dungeon...";
+                    // another room remains to be explored, move player to it
+                    if (player.NextRoomRemains()) {
+                        flavourText = player.MoveToNextRoom();
                         return this;
                     }
 
-                    // mainmenu for now, as MVP.
+                    // if no next room remains, return to mainmenu
                     result = new MainMenu();
                     break;
                 case "levelup":

--- a/Skyscii/Menu/MainMenu.cs
+++ b/Skyscii/Menu/MainMenu.cs
@@ -44,6 +44,14 @@ namespace Skyscii
                     player.Inventory.AddItem(potion);
                     player.Inventory.AddItem(sword);
                     room1.Creatures.Add(player);
+
+                    // room2 setup
+                    Room room2 = new Room("Boss Room", "It looks a little scary!", new List<Sentient>(), new Inventory());
+                    room2.Creatures.Add(new Sentient("Goblin Boss", "This one looks a little overweight", 100, 100, room2));
+                    Item veryGoodSword = new Equippable("MEGASWORD", "The devs really didn't think this through", 10000, 10000, 10000);
+                    room2.Items.AddItem(veryGoodSword);
+                    room1.NextRoom = room2;
+
                     result = new BattleMenu(player);
                     break;
                 case "quit":

--- a/Skyscii/Room.cs
+++ b/Skyscii/Room.cs
@@ -60,12 +60,12 @@ namespace Skyscii
 
         public string GetDescription()
         {
-            return name;
+            return description;
         }
 
         public string GetName()
         {
-            return description;
+            return name;
         }
     }
 }

--- a/Skyscii/SentientStuff/Sentient.cs
+++ b/Skyscii/SentientStuff/Sentient.cs
@@ -270,14 +270,19 @@ namespace Skyscii.SentientStuff
          */
         public string MoveToNextRoom()
         {
-            return "";
+            if (location.NextRoom == null)
+                return "You try to go to the next room, but you're at the end of the dungeon!";
+            else {
+                this.location = location.NextRoom;
+                return "You leave your current room, moving forward into the " + location.GetName();
+            }
         }
 
         /*
          * returns true if another room remains to explore
          */
         public bool NextRoomRemains() {
-            return false;
+            return location.NextRoom != null;
         }
     }
 }

--- a/Skyscii/SentientStuff/Sentient.cs
+++ b/Skyscii/SentientStuff/Sentient.cs
@@ -264,5 +264,20 @@ namespace Skyscii.SentientStuff
             }
             return ai.generateResponse(this);
         }
+
+        /*
+         * Updates Sentient's location to be the current location's nextRoom, if possible.
+         */
+        public string MoveToNextRoom()
+        {
+            return "";
+        }
+
+        /*
+         * returns true if another room remains to explore
+         */
+        public bool NextRoomRemains() {
+            return false;
+        }
     }
 }

--- a/Skyscii/SentientStuff/Sentient.cs
+++ b/Skyscii/SentientStuff/Sentient.cs
@@ -267,13 +267,17 @@ namespace Skyscii.SentientStuff
 
         /*
          * Updates Sentient's location to be the current location's nextRoom, if possible.
+         * removes the player from the old location's sentient list
+         * adds the player to the new location's sentient list
          */
         public string MoveToNextRoom()
         {
             if (location.NextRoom == null)
                 return "You try to go to the next room, but you're at the end of the dungeon!";
             else {
+                this.location.Creatures.Remove(this);
                 this.location = location.NextRoom;
+                this.location.Creatures.Add(this);
                 return "You leave your current room, moving forward into the " + location.GetName();
             }
         }

--- a/SkysciiTests/SentientStuff/SentientTests.cs
+++ b/SkysciiTests/SentientStuff/SentientTests.cs
@@ -172,26 +172,28 @@ namespace Skyscii.SentientStuff.Tests
             player.UnequipItem("sword");
             Assert.AreEqual(PLAYER_STARTING_ATTACK, player.Stats.Attack);
         }
-
-
-        // TODO:
-        /*
+        
+        // NOTE: logic check that the current room is cleared is done in the BattleMenu
+        // ie, the 'moveon' command will only be available on Sentient.LastOneStanding()
+        // therefore, Sentient does not currently check that current room is cleared before moving.
         [TestMethod()]
         public void movingShouldUpdateCurrentRoom()
         {
             setup();
             Room room2 = new Room("new room", "its a new room!", new List<Sentient>(), inv);
-            // BLOCKED: cannot implement without nextRoom variable in Room class.
-            Assert.Fail("unimplemented");
-        }
+            room.NextRoom = room2;
+            goblin.Stats.Health.Increment(-99999);
+            // initial room
+            Assert.AreEqual(player.Location, room);
+            // another room should remain, as we are still in the first room
+            Assert.IsTrue(player.NextRoomRemains());
 
-        [TestMethod()]
-        public void MovingWhenInLastRoomShouldSetWinnerFlag()
-        {
-            setup();
-            // BLOCKED: cannot implement without nextRoom variable in Room class.
-            Assert.Fail("unimplemented");
+            // move to next room
+            String result = player.MoveToNextRoom();
+            Assert.AreEqual(player.Location, room2);
+
+            // another room doesn't exist, as this is the last room.
+            Assert.IsFalse(player.NextRoomRemains());
         }
-        */
     }
 }


### PR DESCRIPTION
After killing all enemies in the current room, the player can move to the next room with the "moveon" command. I have modified the MainMenu such that this can be play-tested by running the game. 
This has unveiled some new bugs; ie, the player won't die properly, and have created tickets on Trello to reflect this. I believe this ticket is complete, though. :)
A unit test for the the Sentient.MoveToNextRoom and Sentient.NextRoomRemains functionality have been added, too.