### PR TITLE
Feature/sentients should hand over loot on death

### DIFF
--- a/Skyscii/Menu/MainMenu.cs
+++ b/Skyscii/Menu/MainMenu.cs
@@ -64,7 +64,9 @@ namespace Skyscii
             {
                 case "play":
                     Room room1 = new Room("room", "it's a room", new List<Sentient>(), new Inventory());
-                    room1.Creatures.Add(new Sentient("goblin", "He is green and mean!", 10, 50, room1));
+                    Sentient goblin = new Sentient("goblin", "He is green and mean!", 10, 50, room1);
+                    
+                    room1.Creatures.Add(goblin);
                     Sentient player = new Sentient("player", "it's you!", 10, 50, room1);
 
                     /*
@@ -84,6 +86,10 @@ namespace Skyscii
                     player.Inventory.AddItem(items.GetPotion());
 
                     room1.Creatures.Add(player);
+
+                    // here just to playtest looting items from corpses.
+                    goblin.Inventory.AddItem(items.GetEquipment());
+                    goblin.Inventory.AddCrests(30);
 
 
                     // room2 setup

--- a/Skyscii/SentientStuff/Sentient.cs
+++ b/Skyscii/SentientStuff/Sentient.cs
@@ -148,14 +148,29 @@ namespace Skyscii.SentientStuff
                 enemyCreature.ApplyModifier(0, -1 * stats.Attack, 0);
                 if (enemyCreature.IsAlive())
                     return name + " attacks " + targetName + " for " + stats.Attack + " points of damage!";
-                else {
-                    // TODO: lazy expgained, should be more fun
+                else { // you have killed someone!
+
+                    // get experience from your kill
                     int expGained = 20 * enemyCreature.stats.Exp.GetLevel();
                     stats.Exp.Increment(expGained);
                     String toReturn =  name +" attacks " + targetName + " for " + stats.Attack + " points of damage, and slays them!\n" +
-                        name + " gains "+expGained+" experience points!";
+                        name + " gains "+expGained+" experience points!\n";
+
+                    // gain items from the fallen
+                    foreach (Item i in enemyCreature.Inventory.GetBag) {
+                        this.Inventory.AddItem(i);
+                        toReturn += name + " looted a " + i.GetName() + " from the " + targetName + " corpse!\n";
+                    }
+
+                    // gain cash from the fallen
+                    this.Inventory.AddCrests(enemyCreature.Inventory.CrestCount);
+                    if (enemyCreature.Inventory.CrestCount > 0) {
+                        toReturn += name + " looted " + enemyCreature.Inventory.CrestCount + " crests from the " + targetName + " corpse!\n";
+                    }
+
                     if (stats.Exp.GetPendingLevelUps() > 0)
-                        toReturn += " It looks like " + name + " can level up!";
+                        toReturn += "\n ** It looks like " + name + " can level up! **";
+
                     return toReturn;
                 }
             }

--- a/SkysciiTests/SentientStuff/SentientTests.cs
+++ b/SkysciiTests/SentientStuff/SentientTests.cs
@@ -212,5 +212,34 @@ namespace Skyscii.SentientStuff.Tests
             setup();
             Assert.AreEqual(10, personwithcrests.Inventory.CrestCount);
         }
+
+        [TestMethod()]
+        public void WhenKilledSentientShouldGiveCrestsToTheirKiller() {
+            setup();
+            goblin.Inventory.AddCrests(10);
+
+            // player starts with no crests
+            Assert.AreEqual(0, player.Inventory.CrestCount);
+
+            player.Stats.Attack = 1000; // player should kill goblin in one hit
+            player.Attack("goblin");
+
+            // player should be given the goblin's crests
+            Assert.AreEqual(10, player.Inventory.CrestCount);
+        }
+
+        [TestMethod()]
+        public void WhenKilledSentientShouldGiveItemsToTheirKiller() {
+            setup();
+
+            Item goblinItem = new Item("goblin treasure", "what does it do?", 0, 0, 0);
+            goblin.Inventory.AddItem(goblinItem);
+            player.Stats.Attack = 1000;
+            player.Attack("goblin");
+
+            Assert.AreEqual(goblinItem, player.Inventory.findTarget("goblin treasure"));
+        }
+
+
     }
 }


### PR DESCRIPTION
Created tests for looting cash and items from killed sentients automatically once they have been killed. Implemented logic, and modified mainmenu such that it can be playtested.
If I have missed any obvious bugs, please let me know! c: